### PR TITLE
Support multiple languages

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -93,30 +94,31 @@ func main() {
 
 	if *list {
 		fmt.Println(strings.Join(listFiles(), "\n"))
-		os.Exit(0)
+		return
 	}
 
 	if len(os.Args) > 1 {
-		arg := os.Args[1]
-
 		_, fileExistsError := fileExists(GitIgnoreExt)
 		if fileExistsError != nil {
-			fmt.Println(fileExistsError)
-			os.Exit(1)
+			log.Fatal(fileExistsError)
 		}
 
-		_, name, gitIgnoreExistsError := gitIgnoreExists(arg)
-		if gitIgnoreExistsError == nil {
-			url := createUrl(name)
-			content, errDownloadFileContent := downloadFileContent(url)
-			if errDownloadFileContent != nil {
-				fmt.Println(errDownloadFileContent)
+		var content []byte
+		for _, arg := range os.Args[1:] {
+			_, name, err := gitIgnoreExists(arg)
+			if err != nil {
+				log.Fatal(err)
 			}
-			writeFileContent(content)
-		} else {
-			fmt.Println(gitIgnoreExistsError)
-			os.Exit(1)
+
+			url := createUrl(name)
+			argContent, err := downloadFileContent(url)
+			if err != nil {
+				log.Fatal(err)
+			}
+			content = append(content, argContent...)
 		}
+
+		writeFileContent(content)
 	} else {
 		flag.Usage()
 	}

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 		}
 
 		var content []byte
-		for _, arg := range os.Args[1:] {
+		for i, arg := range os.Args[1:] {
 			_, name, err := gitIgnoreExists(arg)
 			if err != nil {
 				log.Fatal(err)
@@ -115,6 +115,16 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
+
+			if i != 0 {
+				// add a blank line for every arg except the first
+				content = append(content, byte('\n'))
+			}
+
+			// add a header with the url of the arg
+			header := fmt.Sprintf("# %s\n\n", url)
+			content = append(content, []byte(header)...)
+
 			content = append(content, argContent...)
 		}
 


### PR DESCRIPTION
Closes #7 

I also took a few liberties to make the code more idiomatic (in my opinion). Let me know if you'd like me to undo those or split them into a different PR:

- `log.Fatal` instead of `fmt.Print` followed by `os.Exit`
- `return` instead of `os.Exit(0)` in `func main`
- `err` as variable name for errors. It's pretty common to use only that name for an error variable, there are several examples on [Effective Go](https://golang.org/doc/effective_go.html).

There are several small changes like these that could be made to make the code more idiomatic. I'd happily send a PR just for those, let me know if you'd like it.

ps: I arrived here through https://medium.com/@jessicatemporal/projetos-brasileiros-para-contribuir-nesse-hacktoberfest-vers%C3%A3o-2018-4925959b9411, thx @jtemporal.